### PR TITLE
HH-61659 debian build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@
 [Original project](https://github.com/esnme/ultrajson).
 
 In that fork are only debian package configs.
+
+## How to build .deb & upload it to the debian repository
+
+* `apt-get install python-all python-all-dev debhelper`
+* `pip install --user stdeb`
+* configure your `~/.dput.cf` (ex. `hh-apps` as the main configuration)
+* configure your gpg keys
+* `git clone git@github.com:hhru/ultrajson.git`
+* set postfix for debian version in `setup.cfg`
+* `cd ultrajson`
+* `python setup.py --command-packages=stdeb.command bdist_deb`
+* `cd deb_dist`
+* `debsign python-ujson_X.Y-hhN_amd64.changes`
+* `dput hh-apps python-ujson_X.Y-hhN_amd64.changes`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[sdist_dsc]
+debian-version: hh1
+maintainer: Nikita Kovalev <n.kovalev@hh.ru>
+package: python-ujson
+source: python-ujson

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ Programming Language :: Python :: 3.2
 """.splitlines()))
 
 module1 = Extension('ujson',
-                    sources = ['./python/ujson.c', 
-                               './python/objToJSON.c', 
-                               './python/JSONtoObj.c', 
-                               './lib/ultrajsonenc.c', 
+                    sources = ['./python/ujson.c',
+                               './python/objToJSON.c',
+                               './python/JSONtoObj.c',
+                               './lib/ultrajsonenc.c',
                                './lib/ultrajsondec.c'],
                     include_dirs = ['./python', './lib'],
                     extra_compile_args=['-D_GNU_SOURCE'])
@@ -43,22 +43,15 @@ def get_version():
     assert m, "version.h must contain UJSON_VERSION macro"
     return m.group(1)
 
-f = open('README.rst')
-try:
-    README = f.read()
-finally:
-    f.close()    
-    
 setup (name = 'ujson',
        version = get_version(),
        description = "Ultra fast JSON encoder and decoder for Python",
-       long_description = README,
        ext_modules = [module1],
        author="Jonas Tarnstrom",
        author_email="jonas.tarnstrom@esn.me",
        download_url="http://github.com/esnme/ultrajson",
        license="BSD License",
-       platforms=['any'],      
+       platforms=['any'],
        url="http://www.esn.me",
        classifiers=CLASSIFIERS,
        )


### PR DESCRIPTION
Вместо реальных файлов для debian обошёлся встроенной поддержкой в setuptools. С ней тут всё вполне работает. Всё по факту компилиться в один .so файл. 
В предстоящем релизе сделаю только amd64.

В 16.04 завезли нативный пакет, когда перейдём будем использовать его:
http://packages.ubuntu.com/xenial/python-ujson

https://jira.hh.ru/browse/HH-61659